### PR TITLE
menu alignment fix

### DIFF
--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -28,4 +28,8 @@
     vertical-align: bottom;;  /* vertical alignment of the inline element */
     height: 100%;
   }
+  
+  .Menu .text-right {
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
text bovenaan was niet gelijk met de inhoud doordat de class .text-align een padding van 15px heeft.